### PR TITLE
Update tests, fix some filename issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,13 +17,13 @@ TEST_DB_NAME=godfish_test
 # One should have a target suffix "-test-teardown", another should have the
 # target suffix "-test-setup" and the last one is just named after the DBMS,
 # which builds the CLI binary.
-DRIVERS=postgres mysql
+DRIVERS ?= postgres mysql
 
 SETUPS=$(addsuffix -test-setup, $(DRIVERS))
 TEARDOWNS=$(addsuffix -test-teardown, $(DRIVERS))
 
-test:
-	go test ./... $(ARGS)
+test: test-teardowns test-setups
+	go test $(ARGS) . $(addprefix ./, $(DRIVERS))
 test-setups: $(SETUPS)
 test-teardowns: $(TEARDOWNS)
 

--- a/filename_test.go
+++ b/filename_test.go
@@ -5,32 +5,70 @@ import (
 	"time"
 )
 
-func mustMakeFilename(ver string, dir Direction, name string) filename {
-	out, err := makeFilename(ver, dir, name)
-	if err != nil {
-		panic(err)
-	}
-	return out
-}
-
 func TestFilename(t *testing.T) {
-	const (
-		version = "20191118121314"
-		name    = "test"
-	)
-	actual := []filename{
-		mustMakeFilename(version, DirForward, name),
-		mustMakeFilename(version, DirReverse, name),
+	tests := []struct {
+		version   string
+		direction Direction
+		name      string
+		expOut    filename
+		expErr    bool
+	}{
+		{
+			version:   "20191118121314",
+			direction: DirForward,
+			name:      "test",
+			expOut:    filename("forward-20191118121314-test.sql"),
+		},
+		{
+			version:   "20191118121314",
+			direction: DirReverse,
+			name:      "test",
+			expOut:    filename("reverse-20191118121314-test.sql"),
+		},
+		// timestamp too long
+		{
+			version:   "201911181213141516",
+			direction: DirForward,
+			name:      "test",
+			expOut:    filename("forward-20191118121314-test.sql"),
+		},
+		// timestamp too short
+		{
+			version:   "201911181213",
+			direction: DirForward,
+			name:      "test",
+			expErr:    true,
+		},
+		// unknown direction
+		{
+			version: "20191118121314",
+			name:    "test",
+			expErr:  true,
+		},
+		// name has dashes
+		{
+			version:   "20191118121314",
+			direction: DirForward,
+			name:      "foo-bar",
+			expOut:    filename("forward-20191118121314-foo-bar.sql"),
+		},
+		// just bad
+		{
+			name:   "test",
+			expErr: true,
+		},
 	}
-	expected := []filename{
-		filename("forward-20191118121314-test.sql"),
-		filename("reverse-20191118121314-test.sql"),
-	}
-	for i, name := range actual {
-		if name != expected[i] {
+	for i, test := range tests {
+		out, err := makeFilename(test.version, test.direction, test.name)
+		if !test.expErr && err != nil {
+			t.Errorf("test %d; unexpected error; %v", i, err)
+		} else if test.expErr && err == nil {
+			t.Errorf("test %d; expected error but did not get one", i)
+		}
+		if out != test.expOut {
 			t.Errorf(
-				"wrong filename; got %q, expected %q",
-				name, expected[i],
+				"test %d; wrong filename; got %q, expected %q",
+				i, out, test.expOut,
 			)
 		}
 	}
@@ -51,40 +89,67 @@ func mustMakeMigration(version string, direction Direction, name string) Migrati
 func TestParseMigration(t *testing.T) {
 	tests := []struct {
 		filename filename
-		expected Migration
+		expOut   Migration
+		expErr   bool
 	}{
 		{
 			filename: filename("forward-20191118121314-test.sql"),
-			expected: mustMakeMigration("20191118121314", DirForward, "test"),
+			expOut:   mustMakeMigration("20191118121314", DirForward, "test"),
 		},
 		{
 			filename: filename("reverse-20191118121314-test.sql"),
-			expected: mustMakeMigration("20191118121314", DirReverse, "test"),
+			expOut:   mustMakeMigration("20191118121314", DirReverse, "test"),
+		},
+		// no extension
+		{
+			filename: filename("forward-20191118121314-test"),
+			expOut:   mustMakeMigration("20191118121314", DirForward, "test"),
+		},
+		// timestamp too long
+		{
+			filename: filename("forward-201911181213141516-test.sql"),
+			expOut:   mustMakeMigration("20191118121314", DirForward, "516-test"),
+		},
+		// timestamp too short
+		{filename: filename("forward-201911181213-bar.sql"), expErr: true},
+		// unknown direction
+		{filename: filename("foo-20191118121314-bar.sql"), expErr: true},
+		// just bad
+		{filename: filename("foo-bar"), expErr: true},
+		// name has a delimiter
+		{
+			filename: filename("forward-20191118121314-foo-bar.sql"),
+			expOut:   mustMakeMigration("20191118121314", DirForward, "foo-bar"),
 		},
 	}
 
 	for i, test := range tests {
 		actual, err := parseMigration(test.filename)
-		if err != nil {
-			t.Error(err)
-			return
+		if !test.expErr && err != nil {
+			t.Errorf("test %d; %v", i, err)
+			continue
+		} else if test.expErr && err == nil {
+			t.Errorf("test %d; expected error but did not get one", i)
+			continue
+		} else if test.expErr && err != nil {
+			continue // ok
 		}
-		if actual.Direction() != test.expected.Direction() {
+		if actual.Direction() != test.expOut.Direction() {
 			t.Errorf(
 				"test %d; wrong Direction; expected %s, got %s",
-				i, test.expected.Direction(), actual.Direction(),
+				i, test.expOut.Direction(), actual.Direction(),
 			)
 		}
-		if actual.Name() != test.expected.Name() {
+		if actual.Name() != test.expOut.Name() {
 			t.Errorf(
 				"test %d; wrong Name; expected %s, got %s",
-				i, test.expected.Name(), actual.Name(),
+				i, test.expOut.Name(), actual.Name(),
 			)
 		}
-		if !actual.Timestamp().Equal(test.expected.Timestamp()) {
+		if !actual.Timestamp().Equal(test.expOut.Timestamp()) {
 			t.Errorf(
 				"test %d; wrong Timestamp; expected %s, got %s",
-				i, test.expected.Timestamp(), actual.Timestamp(),
+				i, test.expOut.Timestamp(), actual.Timestamp(),
 			)
 		}
 	}

--- a/godfish.go
+++ b/godfish.go
@@ -409,7 +409,9 @@ type Driver interface {
 	DSN() DSN
 
 	// AppliedVersions queries the schema migrations table for migration
-	// versions that have been executed against the database.
+	// versions that have been executed against the database. If the schema
+	// migrations table does not exist, the returned error should be
+	// ErrSchemaMigrationsDoesNotExist.
 	AppliedVersions() (AppliedVersions, error)
 	// CreateSchemaMigrationsTable should create a table to record migration
 	// versions once they've been applied. The version should be a timestamp as

--- a/godfish.go
+++ b/godfish.go
@@ -48,21 +48,24 @@ const (
 type filename string
 
 // makeFilename creates a filename based on the independent parts. Format:
-// "${direction}-2006010215040506-${name}.sql"
+// "${direction}-${version}-${name}.sql"
 func makeFilename(version string, direction Direction, name string) (filename, error) {
-	if len(version) != len(TimeFormat) {
+	vLen := len(version)
+	if vLen < len(TimeFormat) {
 		return "", fmt.Errorf("version must have length %d", len(TimeFormat))
-	} else if match, err := regexp.MatchString(`\d{14}`, version); err != nil {
+	} else if vLen > len(TimeFormat) {
+		version = version[:len(TimeFormat)]
+	}
+	if match, err := regexp.MatchString(`\d{14}`, version); err != nil {
 		return "", fmt.Errorf("developer error %v", err)
 	} else if !match {
 		return "", fmt.Errorf("version %q does not match pattern", version)
 	}
+
 	if direction == DirUnknown {
 		return "", fmt.Errorf("cannot have unknown direction")
 	}
-	if strings.Contains(name, filenameDelimeter) {
-		return "", fmt.Errorf("name %q cannot contain %q", name, filenameDelimeter)
-	}
+
 	dir := strings.ToLower(direction.String()) + filenameDelimeter
 	ver := version + filenameDelimeter
 	return filename(dir + ver + name + ".sql"), nil
@@ -72,23 +75,29 @@ func parseMigration(name filename) (mig Migration, err error) {
 	var ts time.Time
 	var dir Direction
 	base := filepath.Base(string(name))
-	parts := strings.Split(base, filenameDelimeter)
 
-	if strings.ToLower(parts[0]) == "forward" {
+	if strings.HasPrefix(base, strings.ToLower(DirForward.String())) {
 		dir = DirForward
-	} else if strings.ToLower(parts[0]) == "reverse" {
+	} else if strings.HasPrefix(base, strings.ToLower(DirReverse.String())) {
 		dir = DirReverse
 	} else {
-		err = fmt.Errorf("unknown Direction %q", parts[1])
+		err = errInvalidFilename
 		return
 	}
-
-	ts, err = time.Parse(TimeFormat, parts[1])
-	if err != nil {
+	// index of the start of timestamp
+	i := len(dir.String()) + len(filenameDelimeter)
+	timestamp := string(base[i : i+len(TimeFormat)])
+	if ts, err = time.Parse(TimeFormat, timestamp); err != nil {
 		return
 	}
+	// index of the start of migration name
+	j := i + len(timestamp) + len(filenameDelimeter)
 
-	mig, err = newMutation(ts, dir, strings.TrimSuffix(parts[2], ".sql"))
+	mig, err = newMutation(
+		ts,
+		dir,
+		strings.TrimSuffix(string(base[j:]), ".sql"),
+	)
 	return
 }
 
@@ -275,6 +284,7 @@ var (
 	// ErrSchemaMigrationsDoesNotExist means there is no database table to
 	// record migration status.
 	ErrSchemaMigrationsDoesNotExist = errors.New("table \"schema_migrations\" does not exist")
+	errInvalidFilename              = errors.New("invalid filename")
 )
 
 // ApplyMigration runs a migration at directoryPath with the specified version
@@ -608,8 +618,12 @@ func listAvailableMigrations(directoryPath string, direction Direction) (out []M
 		sort.Sort(sort.Reverse(sort.StringSlice(filenames)))
 	}
 	for _, fn := range filenames {
-		var mig Migration
-		if mig, err = parseMigration(filename(fn)); err != nil {
+		mig, ierr := parseMigration(filename(fn))
+		if ierr == errInvalidFilename {
+			fmt.Println(ierr)
+			continue
+		} else if ierr != nil {
+			err = ierr
 			return
 		}
 		dir := mig.Direction()


### PR DESCRIPTION
#### test: Update tests

Most of the tests were operating on no migration files at all. This would catch very grave errors, but is not a realistic scenario. Add setup and teardown steps for every subtest so there is some data.

We can indirectly test that the Driver's AppliedVersions method returns the correct error value by removing the unit tests that create the schema migration table. It should be called as needed by running a migration. If it's not, then listing applied versions will fail.

Add driver selectivity to Makefile for better local development.

#### fix: Improve filename interpretation

Closes issue #1

- Migration files may not always be in a directory with other sql files.  If the filename can't be parsed, then skip. Splitting by a (somewhat arbitrary) delimiter is not a great idea. Probably better to look for tokens and use length of segments.
- Handle filenames with long version timestamps.
- Remove stupid restrictions on filenames such as the one that prevented dashes from being in the migration name.
- Update tests for formatting & parsing migrations, filenames.

---

NOTE: previously this PR had some updates to error handling and minor breaking changes (removed some exported errors). Link d3c9cd1. Going to do that another time.